### PR TITLE
Fix microsecond date/time parsing

### DIFF
--- a/api/source/main/python/datacube/api/model.py
+++ b/api/source/main/python/datacube/api/model.py
@@ -32,6 +32,8 @@ __author__ = "Simon Oldfield"
 
 
 import logging
+from datetime import datetime
+import re
 from enum import Enum
 import os
 
@@ -429,11 +431,52 @@ def warp_file_paths(path):
 
     return path
 
+# a regex to match an "ISO8601-like" datetime string
 
-# TODO
+DT_PAT = re.compile( \
+    "(?:.*)" + \
+    "(?P<year>\\d{4})" + "-" + \
+    "(?P<month>\\d{2})" + "-" + \
+    "(?P<day>\\d{2})" + "(?:T|\\s+)" + \
+    "(?P<hrs>\\d{2})" + "(?::|-)" + \
+    "(?P<mins>\\d{2})" + "(?::|-)" + \
+    "(?P<secs>\\d{2})" + \
+    "\\.?(?P<usecs>\d+)?" +
+    "(?:.*)")
+
 def parse_datetime(s):
-    from datetime import datetime
-    return datetime.strptime(s[:len("YYYY-MM-DD HH:MM:SS")], "%Y-%m-%d %H:%M:%S")
+    """
+    Search the supplied string for a "ISO8601-like" datetime 
+    and return equivalent datetime object.
+
+    This function will handle all know date/time formats used in AGDC database and 
+    file name.
+
+    :param s:
+       String containing an ISO8601 datetime string or 
+       some close approximation
+
+    :return:
+       A naive datetime instance corresponding to a matching
+       datetime found in the dt_string, or None if no datetime
+       is found
+    """
+
+    dt = None
+    m = DT_PAT.match(s)
+    if m is not None:
+        usecs = 0
+        if m.group('usecs') is not None:
+            usecs = int(m.group('usecs'))
+        dt = datetime( \
+            int(m.group('year')),
+            int(m.group('month')),
+            int(m.group('day')),
+            int(m.group('hrs')),
+            int(m.group('mins')),
+            int(m.group('secs')),
+            usecs)
+    return dt
 
 
 # TODO TEMPORARY UNTIL WOFS IS AVAILABLE AS INGESTED DATA

--- a/api/source/test/python/datacube/api/test_parse_datetime.py
+++ b/api/source/test/python/datacube/api/test_parse_datetime.py
@@ -1,0 +1,55 @@
+import os
+import unittest
+from datacube.api.model import parse_datetime
+from datetime import datetime
+
+
+class TestConfig(unittest.TestCase):
+
+    def setUp(self):
+        self.with_micros = datetime(2014, 10, 25, 11, 3, 21, 123456)
+        self.no_micros = datetime(2014, 10, 25, 11, 3, 21)
+
+    def tearDown(self):
+        pass
+
+    def test_with_micros(self):
+        dt_string = "2014-10-25 11:03:21.123456"
+        dt = parse_datetime(dt_string)
+        self.assertTrue(dt is not None)
+        self.assertEqual(dt, self.with_micros)
+
+    def test_with_micros_dash_time_sep(self):
+        dt_string = "2014-10-25 11-03-21.123456"
+        dt = parse_datetime(dt_string)
+        self.assertTrue(dt is not None)
+        self.assertEqual(dt, self.with_micros)
+
+    def test_with_micros_T_separator(self):
+        dt_string = "2014-10-25T11:03:21.123456"
+        dt = parse_datetime(dt_string)
+        self.assertTrue(dt is not None)
+        self.assertEqual(dt, self.with_micros)
+
+    def test_with_no_micros(self):
+        dt_string = "2014-10-25 11:03:21"
+        dt = parse_datetime(dt_string)
+        self.assertTrue(dt is not None)
+        self.assertEqual(dt, self.no_micros)
+        self.assertEqual(self.no_micros.microsecond, 0)
+
+    def test_with_zero_micros(self):
+        dt_string = "2014-10-25 11:03:21.0"
+        dt = parse_datetime(dt_string)
+        self.assertTrue(dt is not None)
+        self.assertEqual(dt, self.no_micros)
+        self.assertEqual(self.no_micros.microsecond, 0)
+
+    def test_find_timestamp_in_filepath(self):
+        dt_string = "/g/data/rs0/tiles/EPSG4326_1deg_0.00025pixel/LS5_TM/150_-034/2007/mosaic_cache/LS5_TM_NBAR_150_-034_2014-10-25T11-03-21.123456.vrt"
+        dt = parse_datetime(dt_string)
+        self.assertTrue(dt is not None)
+        self.assertEqual(dt, self.with_micros)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When using Tile.from_csv_record(record) the parse_datetime() does not capture the microsecond element of the timestamp. This cause problems for downstream processing where applications (e.g. WOfS) rely on the full timestamp as an identifier. The alternative of extracting this info from NBAR filenames is not appealing.

The AGDC uses a variety of date/time formats roughly aligned to (but not all compatible with) ISO8601. The proposed function uses a regex to match all formats so far encountered in datacube usage.
